### PR TITLE
Reverse Workflow Order & Add Slider

### DIFF
--- a/src/components/parts/HpoTermRow.vue
+++ b/src/components/parts/HpoTermRow.vue
@@ -138,8 +138,11 @@ input[type='checkbox'] {
     background-color: #e2e2e2;
 }
 .hpo-row-container.disabled {
-    opacity: 0.5;
-    color: grey;
+    color: #3D3D3D;
+}
+.hpo-row-container.disabled > .phenotype-name-span {
+    font-style: italic;
+    opacity: 0.7;
 }
 
 .delete-btn-span {

--- a/src/components/parts/HpoTermRow.vue
+++ b/src/components/parts/HpoTermRow.vue
@@ -140,7 +140,6 @@ input[type='checkbox'] {
 .hpo-row-container.disabled {
     opacity: 0.5;
     color: grey;
-    text-decoration: line-through;
 }
 
 .delete-btn-span {

--- a/src/components/parts/ItemSelector.vue
+++ b/src/components/parts/ItemSelector.vue
@@ -72,7 +72,7 @@
         flex-direction: row;
         justify-content: flex-start;
         align-items: center;
-        padding: 8px 2px 5px 2px;
+        padding: 8px 2px 5px 6px;
         margin: 0px;
         height: fit-content;
 

--- a/src/models/ChartItem.js
+++ b/src/models/ChartItem.js
@@ -54,7 +54,7 @@ class ChartItem {
         this.inheritance = 'unknown';
         this.mother = false;
         this.father = false;
-        this.use = true;
+        this.use = false;
     }
 
     //Getters

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,6 +13,6 @@ export default defineConfig({
             '@': fileURLToPath(new URL('./src', import.meta.url)),
         },
     },
-    base: '/phenoplus/oauth2/redirect/', //staging or dev
-    // base: '/launch/', //production
+    // base: '/phenoplus/oauth2/redirect/', //staging or dev
+    base: '/launch/', //production
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,6 +13,6 @@ export default defineConfig({
             '@': fileURLToPath(new URL('./src', import.meta.url)),
         },
     },
-    // base: '/phenoplus/oauth2/redirect/', //staging or dev
-    base: '/launch/', //production
+    base: '/phenoplus/oauth2/redirect/', //staging or dev
+    // base: '/launch/', //production
 });


### PR DESCRIPTION
This pull request introduces a resizable split-pane user interface to the `MainContainer.vue` component, allowing users to adjust the relative widths of the item selector and note content preview panes using a draggable vertical splitter. The update also includes related style changes for smooth resizing and improved accessibility, as well as minor UI tweaks elsewhere. Additionally, the default state of new `ChartItem` objects is changed to not be used by default.

**Resizable Split-Pane Functionality**
* Added a draggable vertical splitter between the item selector and note content preview panes, enabling dynamic resizing via mouse or touch drag. This includes new state variables (`selectorWidthPct`, `isDragging`), drag event handlers, and dynamic inline styles for both panes and the splitter. (`src/components/MainContainer.vue`, [[1]](diffhunk://#diff-4578fe7c1f3f78b45d91264b8e4769145ebb8d0f6410c6e6b7f19cf032385cd2L21-R21) [[2]](diffhunk://#diff-4578fe7c1f3f78b45d91264b8e4769145ebb8d0f6410c6e6b7f19cf032385cd2L30-R34) [[3]](diffhunk://#diff-4578fe7c1f3f78b45d91264b8e4769145ebb8d0f6410c6e6b7f19cf032385cd2L58-R81) [[4]](diffhunk://#diff-4578fe7c1f3f78b45d91264b8e4769145ebb8d0f6410c6e6b7f19cf032385cd2R162-R164) [[5]](diffhunk://#diff-4578fe7c1f3f78b45d91264b8e4769145ebb8d0f6410c6e6b7f19cf032385cd2R422-R439) [[6]](diffhunk://#diff-4578fe7c1f3f78b45d91264b8e4769145ebb8d0f6410c6e6b7f19cf032385cd2R462-R736)
* Updated related CSS for both panes and the splitter to provide smooth width transitions and proper positioning/appearance during resizing. (`src/components/MainContainer.vue`, [[1]](diffhunk://#diff-4578fe7c1f3f78b45d91264b8e4769145ebb8d0f6410c6e6b7f19cf032385cd2L614-R933) [[2]](diffhunk://#diff-4578fe7c1f3f78b45d91264b8e4769145ebb8d0f6410c6e6b7f19cf032385cd2L623-R943) [[3]](diffhunk://#diff-4578fe7c1f3f78b45d91264b8e4769145ebb8d0f6410c6e6b7f19cf032385cd2R1059-R1097)

**UI and Accessibility Improvements**
* Improved the appearance of disabled HPO term rows by removing strikethrough and changing the color to a subtler gray with italicized text for the phenotype name. (`src/components/parts/HpoTermRow.vue`, [src/components/parts/HpoTermRow.vueL141-R145](diffhunk://#diff-07584945b9cf90566e836ef6521724a239c5a20bda0c79a2f777ccbf5c78afffL141-R145))
* Adjusted padding for item selector rows for better alignment. (`src/components/parts/ItemSelector.vue`, [src/components/parts/ItemSelector.vueL75-R75](diffhunk://#diff-d371d1c2a853fc79591b89845a9b94ba3ed38084276065f8ee21c20db9c44051L75-R75))

**Model Default Behavior**
* Changed the default value of the `use` property in `ChartItem` to `false`, so new terms are not used by default. (`src/models/ChartItem.js`, [src/models/ChartItem.jsL57-R57](diffhunk://#diff-1e1672ca8c9641b8539c7cbc9e1271a152805c33c9a63d710cf065563618599cL57-R57))